### PR TITLE
feat: enable exit 1 if max time is exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,10 @@ Note: default values in dns-loop are
 ![sample_view](https://user-images.githubusercontent.com/16940760/94466451-ae7f0880-017e-11eb-952b-a07a1e97570d.png)
 
 #### Running with custom values:
-This is a sample run using 200 iterations, URL azure.microsoft.com and running the queries every 100 ms
+This is a sample run using 200 iterations, URL azure.microsoft.com, running the queries every 100 ms, and exiting non-zero if any single request takes longer than 1 second
 
 ```
-kubectl exec -it dns-loop -- dns-loop 200 azure.microsoft.com 0.100
+kubectl exec -it dns-loop -- dns-loop 200 azure.microsoft.com 0.100 1
 ```
 
 ![sample_view](https://user-images.githubusercontent.com/16940760/94466883-5a285880-017f-11eb-9e0c-ccd00b9ec7db.png)
-
-
-

--- a/curl-loop
+++ b/curl-loop
@@ -10,16 +10,17 @@ if [[ -z $1 ]] ; then NumberOfTests="10" ; fi
 if [[ -z $2 ]] ; then URL="www.google.com" ; fi
 if [[ -z $3 ]] ; then SleepDuration="0.250" ; fi
 
+curl_loop_exit_code=0
 for ((i=1;i<=$NumberOfTests;i++))
 do
         CurlTime=$(curl -X GET $URL --silent --output /dev/null -w "%{time_namelookup}")
         echo "$CurlTime"
         if [[ -n $MaxTime ]]; then
-                if (( $(echo "$CurlTime > $MaxTime" | bc -l) )); then
-                        exit 1
-                fi
+		if [ $CurlTime \> $MaxTime ]; then
+			curl_loop_exit_code=1
+		fi
         fi
         sleep $SleepDuration
 done
 
-exit 0
+exit $curl_loop_exit_code

--- a/curl-loop
+++ b/curl-loop
@@ -3,6 +3,7 @@
 NumberOfTests=$1
 URL=$2
 SleepDuration=$3
+MaxTime=$4
 
 #Check Vars
 if [[ -z $1 ]] ; then NumberOfTests="10" ; fi
@@ -11,7 +12,13 @@ if [[ -z $3 ]] ; then SleepDuration="0.250" ; fi
 
 for ((i=1;i<=$NumberOfTests;i++))
 do
-        echo "$(curl -X GET $URL --silent --output /dev/null -w "%{time_namelookup}")"
+        CurlTime=$(curl -X GET $URL --silent --output /dev/null -w "%{time_namelookup}")
+        echo "$CurlTime"
+        if [[ -n $MaxTime ]]; then
+                if (( $(echo "$CurlTime > $MaxTime" | bc -l) )); then
+                        exit 1
+                fi
+        fi
         sleep $SleepDuration
 done
 

--- a/dns-loop
+++ b/dns-loop
@@ -3,6 +3,7 @@
 NumberOfTests=$1
 URL=$2
 SleepDuration=$3
+MaxTime=$4
 
 #Check Vars
 if [[ -z $1 ]] ; then NumberOfTests="100" ; fi
@@ -12,7 +13,7 @@ if [[ -z $3 ]] ; then SleepDuration="0.250" ; fi
 
 echo -e "Runnung DNS loop check with $NumberOfTests iterations and URL $URL ...\n"
 while true;do for s in / - \\ \|; do printf "\r$s";sleep 1;done; done &
-curl-loop $NumberOfTests $URL $SleepDuration | hist -r -x -b $NumberOfTests -c blue
+curl-loop $NumberOfTests $URL $SleepDuration $MaxTime | hist -r -x -b $NumberOfTests -c blue
 kill $!; trap 'kill $!' SIGTERM
 
 exit 0

--- a/dns-loop
+++ b/dns-loop
@@ -10,10 +10,10 @@ if [[ -z $1 ]] ; then NumberOfTests="100" ; fi
 if [[ -z $2 ]] ; then URL="google.com" ; fi
 if [[ -z $3 ]] ; then SleepDuration="0.250" ; fi
 
-
 echo -e "Runnung DNS loop check with $NumberOfTests iterations and URL $URL ...\n"
 while true;do for s in / - \\ \|; do printf "\r$s";sleep 1;done; done &
 curl-loop $NumberOfTests $URL $SleepDuration $MaxTime | hist -r -x -b $NumberOfTests -c blue
+dns_loop_exit_code=${PIPESTATUS[0]}
 kill $!; trap 'kill $!' SIGTERM
 
-exit 0
+exit $dns_loop_exit_code


### PR DESCRIPTION
This PR introduces a 4th positional argument to the `curl-loop` script to allow for quick detection of single high response time requests.